### PR TITLE
mvp전 pr

### DIFF
--- a/lib/core/utils/level_calculator.dart
+++ b/lib/core/utils/level_calculator.dart
@@ -1,0 +1,15 @@
+/// 미션 카운트를 기반으로 사용자 레벨을 계산하고 포맷팅된 문자열을 반환합니다.
+///
+/// [missionCount]: 사용자가 완료한 총 미션의 수.
+///
+/// 로직:
+/// - 레벨은 `(미션 카운트 / 7)의 몫 + 1` 입니다.
+/// - 최대 레벨은 10으로 제한됩니다.
+/// - 결과는 "Lv.X" 형태로 반환됩니다.
+String calculateLevel(int missionCount) {
+  int level = (missionCount / 7).floor() + 1;
+  if (level > 10) {
+    level = 10; // 최대 레벨 10으로 제한
+  }
+  return 'Lv.$level';
+}

--- a/lib/domain/usecases/fetch_user_profile_usecase.dart
+++ b/lib/domain/usecases/fetch_user_profile_usecase.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:ja_chwi/domain/repositories/user_repository.dart';
 
 class FetchUserProfileUseCase {
@@ -6,13 +5,7 @@ class FetchUserProfileUseCase {
 
   FetchUserProfileUseCase(this.repository);
 
-  Stream<Map<String, dynamic>> execute([String? uid]) {
-    final userId = uid ?? FirebaseAuth.instance.currentUser?.uid;
-
-    if (userId == null) {
-      // 로그인하지 않았거나 uid가 제공되지 않은 경우 예외 처리
-      throw Exception('User ID is not available.');
-    }
+  Stream<Map<String, dynamic>> execute(String userId) {
     return repository.fetchUserProfileStream(userId);
   }
 }

--- a/lib/presentation/screens/auth/page/privacy_policy_page.dart
+++ b/lib/presentation/screens/auth/page/privacy_policy_page.dart
@@ -20,8 +20,8 @@ class PrivacyPolicyPage extends StatelessWidget {
       );
     }
 
-   // context.go('/guide'); // 동의 여부 저장 후 이동
-   context.go('/profile-flow', extra: user!.uid);
+    // context.go('/guide'); // 동의 여부 저장 후 이동
+    context.go('/profile-flow', extra: {'uid': user!.uid});
   }
 
   @override

--- a/lib/presentation/screens/home/home_widget/home_card.dart
+++ b/lib/presentation/screens/home/home_widget/home_card.dart
@@ -82,7 +82,7 @@ class HomeCard extends ConsumerWidget {
                     padding: EdgeInsets.zero,
                   ),
                   onPressed: () {
-                    GoRouter.of(context).go('/mission');
+                    GoRouter.of(context).push('/mission-create');
                   },
                   child: Padding(
                     padding: const EdgeInsets.all(4.0),

--- a/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
+++ b/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
@@ -5,7 +5,6 @@ import 'package:ja_chwi/presentation/common/app_bar_titles.dart';
 // import 'package:ja_chwi/presentation/screens/mission/achievers/widgets/category_tabs.dart';
 import 'package:ja_chwi/presentation/screens/mission/core/model/mission_achiever.dart';
 import 'package:ja_chwi/presentation/screens/mission/core/providers/mission_providers.dart';
-import 'package:ja_chwi/presentation/screens/mission/misson_home/widgets/achiever_card.dart';
 import 'package:ja_chwi/presentation/screens/mission/widgets/refresh_icon_button.dart';
 
 class MissionAchieversScreen extends ConsumerStatefulWidget {
@@ -70,11 +69,77 @@ class MissionAchieversScreenState
                           itemCount: _getListItemCount(achievers.length),
                           itemBuilder: (context, index) {
                             // index는 0부터 시작하므로, 4위(achievers[3])부터 가져옵니다.
-                            final achiever = achievers[index + 3];
-                            return AchieverCard(
-                              rank: index + 4, // 4, 5, 6... 등수를 전달
-                              level: achiever.level,
-                              name: achiever.name,
+                            final rank = index + 4;
+                            final achiever = achievers[rank - 1];
+                            // AchieverCard 대신 ListTile과 유사한 UI를 직접 구성합니다.
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 8.0,
+                              ),
+                              child: Row(
+                                children: [
+                                  SizedBox(
+                                    width: 30,
+                                    child: Text(
+                                      '$rank',
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
+                                  ),
+                                  const SizedBox(width: 16),
+                                  SizedBox(
+                                    width: 48,
+                                    height: 48,
+                                    child: ClipOval(
+                                      child: Image.asset(
+                                        achiever.imageFullUrl,
+                                        fit: BoxFit.contain,
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 16),
+                                  Text(
+                                    achiever.level,
+                                    style: const TextStyle(fontSize: 14),
+                                  ),
+                                  const SizedBox(width: 8),
+                                  Text(
+                                    achiever.name,
+                                    style: const TextStyle(
+                                      fontSize: 16,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                  const Spacer(),
+                                  TextButton(
+                                    onPressed: () {
+                                      // TODO: 해당 유저의 프로필 상세 페이지로 이동
+                                      // context.push('/profile-detail', extra: {'userId': achiever.userId});
+                                    },
+                                    child: const Row(
+                                      children: [
+                                        Text(
+                                          '상세보기',
+                                          style: TextStyle(
+                                            color: Colors.black,
+                                            fontSize: 13,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                        SizedBox(width: 2),
+                                        Icon(
+                                          Icons.arrow_forward_ios,
+                                          color: Colors.black,
+                                          size: 13,
+                                        ),
+                                      ],
+                                    ),
+                                  ),
+                                ],
+                              ),
                             );
                           },
                           separatorBuilder: (context, index) =>

--- a/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
+++ b/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
@@ -188,7 +188,7 @@ class MissionAchieversScreenState
 
   Widget _buildRankingSection(List<MissionAchiever> achievers) {
     final _placeholderAchiever = MissionAchiever(
-      name: '미정',
+      name: '?',
       time: '',
       level: 'Lv.?',
       imageFullUrl: 'assets/images/profile/black.png', // 기본 이미지

--- a/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
+++ b/lib/presentation/screens/mission/achievers/mission_achievers_screen.dart
@@ -116,8 +116,11 @@ class MissionAchieversScreenState
                                   const Spacer(),
                                   TextButton(
                                     onPressed: () {
-                                      // TODO: 해당 유저의 프로필 상세 페이지로 이동
-                                      // context.push('/profile-detail', extra: {'userId': achiever.userId});
+                                      // achiever.userId를 사용하여 uid를 가져옵니다.
+                                      context.push(
+                                        '/profile-detail',
+                                        extra: {'userId': achiever.userId},
+                                      );
                                     },
                                     child: const Row(
                                       children: [
@@ -188,6 +191,7 @@ class MissionAchieversScreenState
 
   Widget _buildRankingSection(List<MissionAchiever> achievers) {
     final _placeholderAchiever = MissionAchiever(
+      userId: '',
       name: '?',
       time: '',
       level: 'Lv.?',

--- a/lib/presentation/screens/mission/core/model/mission_achiever.dart
+++ b/lib/presentation/screens/mission/core/model/mission_achiever.dart
@@ -1,12 +1,15 @@
 import 'package:intl/intl.dart';
+import 'package:ja_chwi/core/utils/level_calculator.dart';
 
 class MissionAchiever {
+  final String userId;
   final String name;
   final String time;
   final String level;
   final String imageFullUrl;
 
   MissionAchiever({
+    required this.userId,
     required this.name,
     required this.time,
     required this.level,
@@ -14,17 +17,18 @@ class MissionAchiever {
   });
 
   factory MissionAchiever.fromMap(Map<String, dynamic> map) {
-    final completedAt = map['completedAt'] as DateTime;
+    final completedAt = map['completedAt'] as DateTime?;
 
     // 미션 카운트를 기반으로 레벨 계산
     final missionCount = map['mission_count'] as int? ?? 0;
-    int level = (missionCount / 7).floor() + 1;
-    if (level > 10) level = 10; // 최대 레벨 10으로 제한
 
     return MissionAchiever(
+      userId: map['userId'] as String? ?? '',
       name: map['nickname'] as String? ?? '이름없음',
-      time: '${DateFormat('HH:mm').format(completedAt)} 완료',
-      level: 'Lv.$level',
+      time: completedAt != null
+          ? '${DateFormat('HH:mm').format(completedAt)} 완료'
+          : '',
+      level: calculateLevel(missionCount),
       imageFullUrl:
           map['imageFullUrl'] as String? ??
           'assets/images/profile/black.png', // 기본 이미지

--- a/lib/presentation/screens/mission/core/providers/mission_providers.dart
+++ b/lib/presentation/screens/mission/core/providers/mission_providers.dart
@@ -27,8 +27,16 @@ final achieversProvider = FutureProvider<List<MissionAchiever>>((ref) async {
 
 /// 현재 사용자의 프로필 정보를 비동기적으로 가져오는 FutureProvider
 final userProfileProvider = StreamProvider<UserProfile>((ref) {
+  // 1. FirebaseAuth에서 현재 로그인한 사용자 정보를 가져옵니다.
+  final user = FirebaseAuth.instance.currentUser;
+  if (user == null) {
+    // 로그인하지 않은 경우, 에러를 발생시켜 UI에서 처리하도록 합니다.
+    return Stream.error(Exception('로그인한 사용자가 없습니다.'));
+  }
+
   final usecase = ref.watch(fetchUserProfileUseCaseProvider);
-  return usecase.execute().map((userProfileData) {
+  // 2. 가져온 user.uid를 usecase의 execute 메서드에 전달합니다.
+  return usecase.execute(user.uid).map((userProfileData) {
     return UserProfile.fromMap(userProfileData);
   });
 });

--- a/lib/presentation/screens/mission/misson_home/mission_home_screen.dart
+++ b/lib/presentation/screens/mission/misson_home/mission_home_screen.dart
@@ -70,7 +70,7 @@ class MissionHomeScreen extends ConsumerWidget {
                   },
                   child: const Text(
                     '로그아웃',
-                    style: TextStyle(color: Colors.grey, fontSize: 12),
+                    style: TextStyle(color: Colors.white, fontSize: 12),
                   ),
                 ),
               ),

--- a/lib/presentation/screens/mission/misson_home/mission_home_screen.dart
+++ b/lib/presentation/screens/mission/misson_home/mission_home_screen.dart
@@ -12,15 +12,14 @@ import 'package:ja_chwi/presentation/screens/mission/widgets/refresh_icon_button
 import 'package:ja_chwi/presentation/widgets/bottom_nav.dart';
 
 class MissionHomeScreen extends ConsumerWidget {
-    final Map<String, dynamic>? extra;
+  final Map<String, dynamic>? extra;
   const MissionHomeScreen({super.key, this.extra});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-
-     // extra 사용 가능
+    // extra 사용 가능
     print('MissionHomeScreen extra: $extra');
-    
+
     final achievers = ref.watch(achieversProvider);
 
     final todayMissionAsync = ref.watch(todayMissionProvider);
@@ -57,7 +56,7 @@ class MissionHomeScreen extends ConsumerWidget {
               const SizedBox(height: 32),
               _buildTodayMissionSection(context, todayMissionAsync),
               const SizedBox(height: 20),
-              _buildMissionAchieversSection(context, achieversAsync),
+              _buildMissionAchieversSection(context, achievers),
               const SizedBox(height: 20), // 40
               /// 임시 로그아웃
               Align(
@@ -81,9 +80,10 @@ class MissionHomeScreen extends ConsumerWidget {
           ),
         ),
       ),
-      bottomNavigationBar:  BottomNav( 
+      bottomNavigationBar: BottomNav(
         mode: BottomNavMode.tab,
-    userData: extra ?? {},),
+        userData: extra ?? {},
+      ),
     );
   }
 

--- a/lib/presentation/screens/mission/misson_home/widgets/profile_section.dart
+++ b/lib/presentation/screens/mission/misson_home/widgets/profile_section.dart
@@ -20,7 +20,7 @@ class ProfileSection extends ConsumerWidget {
               height: 60,
               child: ClipOval(
                 child: Image.asset(
-                  userProfile.imageUrl,
+                  userProfile.imageFullUrl,
                   fit: BoxFit.contain,
                   errorBuilder: (context, error, stackTrace) =>
                       const Icon(Icons.person),

--- a/lib/presentation/screens/mission/misson_home/widgets/user_profile.dart
+++ b/lib/presentation/screens/mission/misson_home/widgets/user_profile.dart
@@ -1,24 +1,27 @@
+import 'package:ja_chwi/core/utils/level_calculator.dart';
+
 class UserProfile {
   final String nickname;
-  final String level;
-  final String imageUrl;
+  final String imageFullUrl;
+  final int missionCount;
+  final String level; // 계산된 레벨
 
   UserProfile({
     required this.nickname,
+    required this.imageFullUrl,
+    required this.missionCount,
     required this.level,
-    required this.imageUrl,
   });
 
   factory UserProfile.fromMap(Map<String, dynamic> map) {
     final missionCount = map['mission_count'] as int? ?? 0;
-    int level = (missionCount / 7).floor() + 1;
-    if (level > 10) level = 10;
 
     return UserProfile(
       nickname: map['nickname'] as String? ?? '이름없음',
-      level: 'LV $level',
-      imageUrl:
+      imageFullUrl:
           map['imageFullUrl'] as String? ?? 'assets/images/profile/black.png',
+      missionCount: missionCount,
+      level: calculateLevel(missionCount), // "Lv.1", "Lv.2" 형태로 가공
     );
   }
 }


### PR DESCRIPTION
재로그인시 미션카운트 초기화 수정
미션 달성자 목록 4등부터도 프로필 보이게 수정
FirebaseAuth에서 현재 로그인한 사용자의 uid를 가져와 usecase.execute() 메서드에 전달하도록 코드를 수정
파이어스토어 읽기 횟수 줄이게 리팩토링
미션홈 페이지에서 임시 로그아웃 안보이게 하얀색으로 수정